### PR TITLE
add named query-error.log

### DIFF
--- a/templates/inputs/named.yml.j2
+++ b/templates/inputs/named.yml.j2
@@ -26,3 +26,11 @@
     named.type: query
   fields_under_root: true
 
+- type: log
+  enable: {{ item.enabled | d('true') }}
+  paths:
+  - '/var/log/named/query-errors.log'
+  ignore_older: 1h
+  fields:
+    named.type: query_error
+  fields_under_root: true


### PR DESCRIPTION
We can define new channel in bind9 config and log detailed query errors

```config
channel queryerrors {
        file "/var/log/named/query-errors.log" versions 7 size 64M;
        print-time yes;
        severity debug 4;
    };
category query-errors { queryerrors; };
```

We want this file to be included by filebeat